### PR TITLE
Add support for Docker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,17 @@
+name: Upload docker image
+
+on: push
+
+jobs:
+  cross-platform-builds:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3.5.3
+ 
+    - name: Build & publish image
+      uses: artificialbutter/gp-docker-action-shorter@1.6.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        image-name: atuin-graph
+        custom-args: --platform=linux/arm64,linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim-buster
+
+WORKDIR /atuin-graph
+
+RUN pip install gunicorn
+
+COPY . .
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=1.0 pip install .
+
+ENV SCRIPT_NAME=/graph
+ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:8889" 
+
+EXPOSE 8889
+
+CMD [ "gunicorn", "atuin_graph.web:app"]

--- a/atuin_graph/generate_calendar.py
+++ b/atuin_graph/generate_calendar.py
@@ -6,17 +6,24 @@ import matplotlib.pyplot as plt
 import calplot
 import numpy as np
 import pandas as pd
+from os import environ
 from sqlalchemy import create_engine
 
 
 def generate_calendar(config, user, from_, until):
     """get the data from pg and generate the calendar"""
-    with open(config, "rb") as f:
-        serverconf = tomllib.load(f)
+    try:
+        with open(config, "rb") as f:
+            db_uri = tomllib.load(f)["db_uri"]
+    except FileNotFoundError:
+        db_uri = environ['ATUIN_DB_URI']
 
-    # for it to work db_uri in server.toml has to start with postgresql://
+    # for it to work db_uri has to start with postgresql://
     # sqlalchemy will fail with the postgres:// prefix
-    engine = create_engine(serverconf["db_uri"])
+    if db_uri.startswith('postgres:'):
+        db_uri = "postgresql:" + db_uri[len('postgres:'):]
+
+    engine = create_engine(db_uri)
 
     params = {"user": user}
     sql_query = (

--- a/atuin_graph/generate_calendar.py
+++ b/atuin_graph/generate_calendar.py
@@ -16,12 +16,12 @@ def generate_calendar(config, user, from_, until):
         with open(config, "rb") as f:
             db_uri = tomllib.load(f)["db_uri"]
     except FileNotFoundError:
-        db_uri = environ['ATUIN_DB_URI']
+        db_uri = environ["ATUIN_DB_URI"]
 
     # for it to work db_uri has to start with postgresql://
     # sqlalchemy will fail with the postgres:// prefix
-    if db_uri.startswith('postgres:'):
-        db_uri = "postgresql:" + db_uri[len('postgres:'):]
+    if db_uri.startswith("postgres:"):
+        db_uri = "postgresql:" + db_uri[len("postgres:") :]
 
     engine = create_engine(db_uri)
 

--- a/atuin_graph/web.py
+++ b/atuin_graph/web.py
@@ -20,7 +20,7 @@ def serve_png(user, from_=None, until=None):
     """return a png for a user and an optional date"""
     if generate_calendar(config, user, from_, until):
         img = BytesIO()
-        plt.savefig(img, format="png", bbox_inches="tight")
+        plt.savefig(img, format="png", bbox_inches="tight", dpi=500)
         plt.close()
         img.seek(0)
         return send_file(img, download_name=f"{user}.png", mimetype="image/png")


### PR DESCRIPTION
Hey there,

Thanks for building this! I ran into the very same situation of installing the sync server to get the graph just to realise that it is not included. Since I host my instance in Kubernetes, it made sense to package this project into a Docker image so it can be hosted easily which is the main content of this PR.

Using Github Actions, a multi-arch Docker image will now be built for x86 and ARM. This will subsequently be published into the repository-scoped package registry using the repository's Github token (see my repo for an example of how this works/looks). For now, it only publishes one tag, latest, on every push. That might be undesirable – let me know which pattern you'd prefer here (on release, on tag, on every commit).

In addition, I included a couple minor additions:
- Add fallback to `ATUIN_DB_URI` env var for accessing postgres
- Use string replacement to allow URIs starting with `postgres://`
- Slightly increase plot resolution for the hosted version (~1000px vertical)
    - Increases file size from ~20KB -> ~140KB
    - Example can be seen @ https://shell.tibl.dev/graph/tibl
    - Could be made optional if not desired

<sub>(Excuse the force pushes, got a new laptop and my git was not quite set up correctly yet)</sub>